### PR TITLE
Get imports the usual way

### DIFF
--- a/dataflow/DataObjects/Glacier.py
+++ b/dataflow/DataObjects/Glacier.py
@@ -4,10 +4,9 @@ Created on 18.05.2018
 @author: yvo
 '''
 
-from .Glamos import GlamosData
+from dataflow.DataObjects.Glamos import GlamosData
 from dataflow.DataObjects.MassBalance import MassBalance
-from dataflow.DataObjects.Enumerations.MassBalanceEnumerations import MassBalanceTypeEnum
-#import dataflow.DataObjects.Enumerations.MassBalanceEnumerations.MassBalanceTypeEnum
+
 
 class Glacier(GlamosData):
     '''

--- a/dataflow/DataObjects/Glamos.py
+++ b/dataflow/DataObjects/Glamos.py
@@ -6,6 +6,7 @@ Created on 18.05.2018
 
 import uuid
 
+
 class GlamosData(object):
     '''
     Main class for all GLAMOS-related data-objects sharing the common basic attributes and methods.

--- a/dataflow/DataObjects/LengthChange.py
+++ b/dataflow/DataObjects/LengthChange.py
@@ -4,7 +4,8 @@ Created on 18.05.2018
 @author: yvo
 '''
 
-from .Glamos import GlamosData
+from dataflow.DataObjects.Glamos import GlamosData
+
 
 class LengthChange(GlamosData):
     '''

--- a/dataflow/DataObjects/MassBalance.py
+++ b/dataflow/DataObjects/MassBalance.py
@@ -4,11 +4,12 @@ Created on 31.05.2018
 @author: yvo
 '''
 
-from .Glamos import GlamosData
-from .Enumerations.MassBalanceEnumerations import MassBalanceTypeEnum
-from .Enumerations.MassBalanceEnumerations import AnalysisMethodEnum
+from dataflow.DataObjects.Glamos import GlamosData
+from dataflow.DataObjects.Enumerations.MassBalanceEnumerations import MassBalanceTypeEnum
+from dataflow.DataObjects.Enumerations.MassBalanceEnumerations import AnalysisMethodEnum
 from datetime import date
 from pandas import DataFrame
+
 
 class MassBalance(GlamosData):
     # TODO: Class documentation

--- a/dataflow/DataObjects/VolumeChange.py
+++ b/dataflow/DataObjects/VolumeChange.py
@@ -4,7 +4,8 @@ Created on 11.07.2018
 @author: yvo
 '''
 
-from .Glamos import GlamosData
+from dataflow.DataObjects.Glamos import GlamosData
+
 
 class VolumeChange(GlamosData):
     '''

--- a/dataflow/DataReaders/DataReader.py
+++ b/dataflow/DataReaders/DataReader.py
@@ -4,6 +4,7 @@ Created on 18.05.2018
 @author: yvo
 '''
 
+
 class DataReader(object):
     '''
     Generic main class of all data reader objects used for the GLAMOS data interface.

--- a/dataflow/DataReaders/DatabaseReader.py
+++ b/dataflow/DataReaders/DatabaseReader.py
@@ -4,7 +4,12 @@ Created on 22.05.2018
 @author: yvo
 '''
 
-from .DataReader import DataReader
+from dataflow.DataReaders import DataReader
+import psycopg2
+from psycopg2 import OperationalError
+from .Exceptions.DatabaseConnectionError import DatabaseConnectionError
+import configparser
+
 
 class DatabaseReader(DataReader):
     '''
@@ -27,14 +32,6 @@ class DatabaseReader(DataReader):
         
         self._accessConfigurationFullFileName = accessConfigurationFullFileName
 
-
-
-
-
-import psycopg2
-from psycopg2 import OperationalError
-from .Exceptions.DatabaseConnectionError import DatabaseConnectionError
-import configparser
      
 class PostgreSqlReader(DatabaseReader):
     '''

--- a/dataflow/DataReaders/DatabaseReaders/GlacierReader.py
+++ b/dataflow/DataReaders/DatabaseReaders/GlacierReader.py
@@ -4,9 +4,10 @@ Created on 22.05.2018
 @author: yvo
 '''
 
-from .GlamosDatabaseReader import GlamosDatabaseReader
-from DataObjects.Glacier import Glacier
+from dataflow.DataReaders.DatabaseReaders.GlamosDatabaseReader import GlamosDatabaseReader
+from dataflow.DataObjects.Glacier import Glacier
 import uuid
+
 
 class GlacierReader(GlamosDatabaseReader):
     '''

--- a/dataflow/DataReaders/DatabaseReaders/GlamosDatabaseReader.py
+++ b/dataflow/DataReaders/DatabaseReaders/GlamosDatabaseReader.py
@@ -4,8 +4,9 @@ Created on 22.05.2018
 @author: yvo
 '''
 
-from ..DatabaseReader import PostgreSqlReader
+from dataflow.DataReaders.DatabaseReader import PostgreSqlReader
 from abc import abstractmethod
+
 
 class GlamosDatabaseReader(PostgreSqlReader):
     '''

--- a/dataflow/DataReaders/DatabaseReaders/LengthChangeReader.py
+++ b/dataflow/DataReaders/DatabaseReaders/LengthChangeReader.py
@@ -4,11 +4,10 @@ Created on 22.05.2018
 @author: yvo
 '''
 
-from .GlamosDatabaseReader import GlamosDatabaseReader
+from dataflow.DataReaders.DatabaseReaders.GlamosDatabaseReader import GlamosDatabaseReader
 
-from DataObjects.Glacier import Glacier
-from DataObjects.LengthChange import LengthChange
-from DataObjects.Enumerations.DateEnumerations import DateQualityTypeEnum
+from dataflow.DataObjects.LengthChange import LengthChange
+from dataflow.DataObjects.Enumerations.DateEnumerations import DateQualityTypeEnum
 
 import uuid
 

--- a/dataflow/DataReaders/DatabaseReaders/MassBalanceReader.py
+++ b/dataflow/DataReaders/DatabaseReaders/MassBalanceReader.py
@@ -4,15 +4,15 @@ Created on 12.07.2018
 @author: yvo
 '''
 
-from .GlamosDatabaseReader import GlamosDatabaseReader
-from DataObjects.Glacier import Glacier
-from DataObjects.MassBalance import MassBalanceObservation
-from DataObjects.MassBalance import MassBalanceFixDate
-from DataObjects.Enumerations.MassBalanceEnumerations import MassBalanceTypeEnum
-from DataObjects.Enumerations.MassBalanceEnumerations import AnalysisMethodEnum
-from DataObjects.Exceptions.MassBalanceError import MassBalanceTypeNotDefinedError
-
+from dataflow.DataReaders.DatabaseReaders.GlamosDatabaseReader import GlamosDatabaseReader
+from dataflow.DataObjects.Glacier import Glacier
+from dataflow.DataObjects.MassBalance import MassBalanceObservation
+from dataflow.DataObjects.MassBalance import MassBalanceFixDate
+from dataflow.DataObjects.Enumerations.MassBalanceEnumerations import MassBalanceTypeEnum
+from dataflow.DataObjects.Enumerations.MassBalanceEnumerations import AnalysisMethodEnum
+from dataflow.DataObjects.Exceptions.MassBalanceError import MassBalanceTypeNotDefinedError
 import uuid
+
 
 class MassBalanceReader(GlamosDatabaseReader):
     '''

--- a/dataflow/DataReaders/DatabaseReaders/VolumeChangeReader.py
+++ b/dataflow/DataReaders/DatabaseReaders/VolumeChangeReader.py
@@ -4,10 +4,10 @@ Created on 12.07.2018
 @author: yvo
 '''
 
-from .GlamosDatabaseReader import GlamosDatabaseReader
-from DataObjects.VolumeChange import VolumeChange
-
+from dataflow.DataReaders.DatabaseReaders.GlamosDatabaseReader import GlamosDatabaseReader
+from dataflow.DataObjects.VolumeChange import VolumeChange
 import uuid
+
 
 class VolumeChangeReader(GlamosDatabaseReader):
     '''

--- a/dataflow/DataReaders/Exceptions/DatabaseConnectionError.py
+++ b/dataflow/DataReaders/Exceptions/DatabaseConnectionError.py
@@ -4,6 +4,7 @@ Created on 10.07.2018
 @author: yvo
 '''
 
+
 class DatabaseConnectionError(Exception):
     '''
     Generic error class for database-connection-related errors.

--- a/dataflow/DataReaders/Exceptions/InvalidDataFileError.py
+++ b/dataflow/DataReaders/Exceptions/InvalidDataFileError.py
@@ -4,6 +4,7 @@ Created on 12.07.2018
 @author: yvo
 '''
 
+
 class InvalidDataFileError(Exception):
     '''
     Generic error class for invalid data files.

--- a/dataflow/DataReaders/FileDataReader.py
+++ b/dataflow/DataReaders/FileDataReader.py
@@ -4,13 +4,13 @@ Created on 18.05.2018
 @author: yvo
 '''
 
-from .DataReader import DataReader
+from dataflow.DataReaders.DataReader import DataReader
+
 
 class FileDateReader(DataReader):
     '''
     classdocs
     '''
-
 
     def __init__(self):
         '''

--- a/dataflow/DataReaders/VawFileReaders/LengthChangeReader.py
+++ b/dataflow/DataReaders/VawFileReaders/LengthChangeReader.py
@@ -4,8 +4,9 @@ Created on 18.05.2018
 @author: yvo
 '''
 
-from .VawFileReader import VawFileReader
-from DataObjects.LengthChange import LengthChange
+from dataflow.DataReaders.VawFileReaders import VawFileReader
+from dataflow.DataObjects.LengthChange import LengthChange
+
 
 class LengthChangeReader(VawFileReader):
     '''

--- a/dataflow/DataReaders/VawFileReaders/MassBalanceReader.py
+++ b/dataflow/DataReaders/VawFileReaders/MassBalanceReader.py
@@ -4,15 +4,15 @@ Created on 31.05.2018
 @author: yvo
 '''
 
-from .VawFileReader import VawFileReader
-from DataObjects.MassBalance import MassBalance
-from DataObjects.MassBalance import MassBalanceObservation
-from DataObjects.MassBalance import MassBalanceFixDate
-from DataObjects.MassBalance import ElevationBand
-from DataObjects.MassBalance import MassBalanceTypeEnum
-from DataObjects.Exceptions.MassBalanceError import MassBalanceTypeNotDefinedError
-from DataObjects.Enumerations.DateEnumerations import DateQualityTypeEnum
-from DataObjects.Exceptions.GlacierNotFoundError import GlacierNotFoundError
+from dataflow.DataReaders.VawFileReaders import VawFileReader
+from dataflow.DataObjects.MassBalance import MassBalance
+from dataflow.DataObjects.MassBalance import MassBalanceObservation
+from dataflow.DataObjects.MassBalance import MassBalanceFixDate
+from dataflow.DataObjects.MassBalance import ElevationBand
+from dataflow.DataObjects.MassBalance import MassBalanceTypeEnum
+from dataflow.DataObjects.Exceptions.MassBalanceError import MassBalanceTypeNotDefinedError
+from dataflow.DataObjects.Enumerations.DateEnumerations import DateQualityTypeEnum
+from dataflow.DataObjects.Exceptions.GlacierNotFoundError import GlacierNotFoundError
 import re
 import copy
 

--- a/dataflow/DataReaders/VawFileReaders/VawFileReader.py
+++ b/dataflow/DataReaders/VawFileReaders/VawFileReader.py
@@ -5,11 +5,10 @@ Created on 18.05.2018
 '''
 
 import datetime
-from ..FileDataReader import AsciiFileDateReader
-from DataObjects.Glacier import Glacier
-from DataObjects.Enumerations.DateEnumerations import DateQualityTypeEnum
+from dataflow.DataReaders.FileDataReader import AsciiFileDateReader
+from dataflow.DataObjects.Enumerations.DateEnumerations import DateQualityTypeEnum
+from dataflow.DataObjects.Exceptions.GlacierNotFoundError import GlacierNotFoundError
 
-from DataObjects.Exceptions.GlacierNotFoundError import GlacierNotFoundError
 
 class VawFileReader(AsciiFileDateReader):
     '''

--- a/dataflow/DataReaders/VawFileReaders/VolumeChangeReader.py
+++ b/dataflow/DataReaders/VawFileReaders/VolumeChangeReader.py
@@ -6,9 +6,10 @@ Created on 11.07.2018
 
 from .VawFileReader import VawFileReader
 import re
-from DataObjects.Exceptions.GlacierNotFoundError import GlacierNotFoundError
-from DataObjects.VolumeChange import VolumeChange
-from ..Exceptions.InvalidDataFileError import InvalidDataFileError
+from dataflow.DataObjects.Exceptions.GlacierNotFoundError import GlacierNotFoundError
+from dataflow.DataObjects.VolumeChange import VolumeChange
+from dataflow.DataReaders.Exceptions.InvalidDataFileError import InvalidDataFileError
+
 
 class VolumeChangeReader(VawFileReader):
     '''

--- a/dataflow/DataReadersTests/MassBalanceReaderTests.py
+++ b/dataflow/DataReadersTests/MassBalanceReaderTests.py
@@ -6,10 +6,10 @@ Created on 06.07.2018
 import unittest
 import configparser
 
-from DataReaders.VawFileReaders.MassBalanceReader import MassBalanceReader
-from DataObjects.Glacier import Glacier
-from DataObjects.MassBalance import MassBalanceObservation
-from DataObjects.MassBalance import MassBalanceFixDate
+from dataflow.DataReaders.VawFileReaders.MassBalanceReader import MassBalanceReader
+from dataflow.DataObjects.Glacier import Glacier
+from dataflow.DataObjects.MassBalance import MassBalanceObservation
+from dataflow.DataObjects.MassBalance import MassBalanceFixDate
 
 class MassBalanceReaderTests(unittest.TestCase):
     '''

--- a/dataflow/DataReadersTests/VolumeChangeReaderTests.py
+++ b/dataflow/DataReadersTests/VolumeChangeReaderTests.py
@@ -7,9 +7,9 @@ Created on 11.07.2018
 import unittest
 import datetime
 
-from DataReaders.VawFileReaders.VolumeChangeReader import VolumeChangeReader
-from DataObjects.Glacier import Glacier
-from DataObjects.Exceptions.GlacierNotFoundError import GlacierNotFoundError
+from dataflow.DataReaders.VawFileReaders.VolumeChangeReader import VolumeChangeReader
+from dataflow.DataObjects.Glacier import Glacier
+from dataflow.DataObjects.Exceptions.GlacierNotFoundError import GlacierNotFoundError
 
 
 class VolumeChangeReaderTest(unittest.TestCase):

--- a/dataflow/DataWriters/DataWriter.py
+++ b/dataflow/DataWriters/DataWriter.py
@@ -6,6 +6,7 @@ Created on 18.05.2018
 
 import logging
 
+
 class DataWriter(object):
     '''
     Generic main class of all data writer objects used for the GLAMOS data interface.

--- a/dataflow/DataWriters/DatabaseWriter.py
+++ b/dataflow/DataWriters/DatabaseWriter.py
@@ -4,10 +4,10 @@ Created on 22.05.2018
 @author: yvo
 '''
 
-from .DataWriter import DataWriter
+from dataflow.DataWriters.DataWriter import DataWriter
+
 
 # TODO: Simplifying the database classes. One super class for Readers and Writers.
-
 class DatabaseWriter(DataWriter):
     '''
     classdocs

--- a/dataflow/DataWriters/DatabaseWriters/GlamosDatabaseWriter.py
+++ b/dataflow/DataWriters/DatabaseWriters/GlamosDatabaseWriter.py
@@ -3,10 +3,11 @@ Created on 22.05.2018
 
 @author: yvo
 '''
-from ..DatabaseWriter import PostgreSqlWriter
+from dataflow.DataWriters.FileWriters import PostgreSqlWriter
 import psycopg2
 import configparser
 import logging
+
 
 class GlamosDatabaseWriter(PostgreSqlWriter):
     '''

--- a/dataflow/DataWriters/DatabaseWriters/LengthChangeWriter.py
+++ b/dataflow/DataWriters/DatabaseWriters/LengthChangeWriter.py
@@ -4,10 +4,11 @@ Created on 22.05.2018
 @author: yvo
 '''
 
-from .GlamosDatabaseWriter import GlamosDatabaseWriter
-from DataObjects.Glacier import Glacier
-from DataObjects.LengthChange import LengthChange
+from dataflow.DataWriters.DatabaseWriters.GlamosDatabaseWriter import GlamosDatabaseWriter
+from dataflow.DataObjects.Glacier import Glacier
+from dataflow.DataObjects.LengthChange import LengthChange
 import uuid
+
 
 class LengthChangeWriter(GlamosDatabaseWriter):
     '''

--- a/dataflow/DataWriters/DatabaseWriters/MassBalanceWriter.py
+++ b/dataflow/DataWriters/DatabaseWriters/MassBalanceWriter.py
@@ -4,8 +4,9 @@ Created on 15.06.2018
 @author: yvo
 '''
 
-from .GlamosDatabaseWriter import GlamosDatabaseWriter
+from dataflow.DataWriters.DatabaseWriters.GlamosDatabaseWriter import GlamosDatabaseWriter
 import logging
+
 
 class MassBalanceWriter(GlamosDatabaseWriter):
     '''

--- a/dataflow/DataWriters/DatabaseWriters/VolumeChangeWriter.py
+++ b/dataflow/DataWriters/DatabaseWriters/VolumeChangeWriter.py
@@ -4,7 +4,7 @@ Created on 11.07.2018
 @author: yvo
 '''
 
-from .GlamosDatabaseWriter import GlamosDatabaseWriter
+from dataflow.DataWriters.DatabaseWriters.GlamosDatabaseWriter import GlamosDatabaseWriter
 import logging
 
 class VolumeChangeWriter(GlamosDatabaseWriter):

--- a/dataflow/DataWriters/FileWriters/Database/LengthChangeWriter.py
+++ b/dataflow/DataWriters/FileWriters/Database/LengthChangeWriter.py
@@ -4,8 +4,8 @@ Created on 18.05.2018
 @author: yvo
 '''
 
-from ..FileWriter import FileWriter
-from DataObjects.Glacier import Glacier
+from dataflow.DataWriters.FileWriters.FileWriter import FileWriter
+
 
 class CopyLengthChangeData(FileWriter):
     '''

--- a/dataflow/DataWriters/FileWriters/FileWriter.py
+++ b/dataflow/DataWriters/FileWriters/FileWriter.py
@@ -4,7 +4,8 @@ Created on 18.05.2018
 @author: yvo
 '''
 
-from ..DataWriter import DataWriter
+from dataflow.DataWriters.DataWriter import DataWriter
+
 
 class FileWriter(DataWriter):
     '''

--- a/dataflow/insertDatabaseMassbalance.py
+++ b/dataflow/insertDatabaseMassbalance.py
@@ -6,12 +6,12 @@ Created on 18.05.2018
 Main script to import all VAW mass-balance data files into the GLAMOS database.
 '''
 
-from DataWriters.FileWriters.Database.LengthChangeWriter import CopyLengthChangeData
-from DataWriters.DatabaseWriters.MassBalanceWriter import MassBalanceWriter
-from DataReaders.VawFileReaders.LengthChangeReader import LengthChangeReader
-from DataReaders.VawFileReaders.MassBalanceReader import MassBalanceReader
-from DataReaders.DatabaseReaders.GlacierReader import GlacierReader
-from DataObjects.Exceptions.GlacierNotFoundError import GlacierNotFoundError
+from dataflow.DataWriters.FileWriters.Database.LengthChangeWriter import CopyLengthChangeData
+from dataflow.DataWriters.DatabaseWriters.MassBalanceWriter import MassBalanceWriter
+from dataflow.DataReaders.VawFileReaders.LengthChangeReader import LengthChangeReader
+from dataflow.DataReaders.VawFileReaders.MassBalanceReader import MassBalanceReader
+from dataflow.DataReaders.DatabaseReaders.GlacierReader import GlacierReader
+from dataflow.DataObjects.Exceptions.GlacierNotFoundError import GlacierNotFoundError
 
 import configparser
 import os

--- a/dataflow/insertDatabaseVolumeChange.py
+++ b/dataflow/insertDatabaseVolumeChange.py
@@ -9,11 +9,11 @@ Main script to import all VAW volume change data files into the GLAMOS database.
 import configparser
 import os
 
-from DataReaders.DatabaseReaders.GlacierReader import GlacierReader
-from DataObjects.Exceptions.GlacierNotFoundError import GlacierNotFoundError
-from DataWriters.DatabaseWriters.VolumeChangeWriter import VolumeChangeWriter
-from DataReaders.VawFileReaders.VolumeChangeReader import VolumeChangeReader
-from DataReaders.Exceptions.InvalidDataFileError import InvalidDataFileError
+from dataflow.DataReaders.DatabaseReaders.GlacierReader import GlacierReader
+from dataflow.DataObjects.Exceptions.GlacierNotFoundError import GlacierNotFoundError
+from dataflow.DataWriters.DatabaseWriters.VolumeChangeWriter import VolumeChangeWriter
+from dataflow.DataReaders.VawFileReaders.VolumeChangeReader import VolumeChangeReader
+from dataflow.DataReaders.Exceptions.InvalidDataFileError import InvalidDataFileError
 
 config = configparser.ConfigParser()
 config.read("dataflow.cfg")

--- a/dataflow/sampelPolymorphismDatabaseReaders.py
+++ b/dataflow/sampelPolymorphismDatabaseReaders.py
@@ -11,10 +11,10 @@ import configparser
 import os
 import sys
 
-from DataReaders.DatabaseReaders.GlacierReader import GlacierReader
-from DataReaders.DatabaseReaders.VolumeChangeReader import VolumeChangeReader
-from DataReaders.DatabaseReaders.LengthChangeReader import LengthChangeReader
-from DataReaders.DatabaseReaders.MassBalanceReader import MassBalanceReader
+from dataflow.DataReaders.DatabaseReaders.GlacierReader import GlacierReader
+from dataflow.DataReaders.DatabaseReaders.VolumeChangeReader import VolumeChangeReader
+from dataflow.DataReaders.DatabaseReaders.LengthChangeReader import LengthChangeReader
+from dataflow.DataReaders.DatabaseReaders.MassBalanceReader import MassBalanceReader
 
 
 def listData(glaciers):

--- a/dataflow/sampleGetGlaciers.py
+++ b/dataflow/sampleGetGlaciers.py
@@ -16,7 +16,7 @@ Preconditions:
 import os
 
 # Import of the reader objects.
-from DataReaders.DatabaseReaders.GlacierReader import GlacierReader
+from dataflow.DataReaders.DatabaseReaders.GlacierReader import GlacierReader
 
 # Private configuration file for the database access.
 

--- a/dataflow/sampleGetLengthChanges.py
+++ b/dataflow/sampleGetLengthChanges.py
@@ -14,8 +14,8 @@ Preconditions:
 '''
 
 # Import of the reader objects.
-from DataReaders.DatabaseReaders.GlacierReader import GlacierReader
-from DataReaders.DatabaseReaders.LengthChangeReader import LengthChangeReader
+from dataflow.DataReaders.DatabaseReaders.GlacierReader import GlacierReader
+from dataflow.DataReaders.DatabaseReaders.LengthChangeReader import LengthChangeReader
 
 # Private configuration file for the database access.
 privateDatabaseAccessConfiguration = r".\databaseAccessConfiguration.private.cfg"

--- a/dataflow/sampleGetMassBalanceDataFrame.py
+++ b/dataflow/sampleGetMassBalanceDataFrame.py
@@ -11,10 +11,10 @@ import configparser
 import os
 import sys
 
-from DataReaders.DatabaseReaders.GlacierReader import GlacierReader
-from DataReaders.DatabaseReaders.VolumeChangeReader import VolumeChangeReader
-from DataReaders.DatabaseReaders.LengthChangeReader import LengthChangeReader
-from DataReaders.DatabaseReaders.MassBalanceReader import MassBalanceReader
+from dataflow.DataReaders.DatabaseReaders.GlacierReader import GlacierReader
+from dataflow.DataReaders.DatabaseReaders.VolumeChangeReader import VolumeChangeReader
+from dataflow.DataReaders.DatabaseReaders.LengthChangeReader import LengthChangeReader
+from dataflow.DataReaders.DatabaseReaders.MassBalanceReader import MassBalanceReader
 
 def printMassBalanceDataFrames(glaciers):
     

--- a/dataflow/samplePlotMassBalance.py
+++ b/dataflow/samplePlotMassBalance.py
@@ -4,22 +4,23 @@ Created on 18.05.2018
 @author: yvo
 '''
 
-from DataWriters.FileWriters.Database.LengthChangeWriter import CopyLengthChangeData
-from DataWriters.DatabaseWriters.MassBalanceWriter import MassBalanceWriter
-from DataReaders.VawFileReaders.LengthChangeReader import LengthChangeReader
-from DataReaders.VawFileReaders.MassBalanceReader import MassBalanceReader
-from DataReaders.DatabaseReaders.GlacierReader import GlacierReader
-from DataObjects.Exceptions.GlacierNotFoundError import GlacierNotFoundError
-from DataObjects.MassBalance import MassBalanceObservation
-from DataObjects.MassBalance import MassBalanceFixDate
-from DataObjects.Enumerations.MassBalanceEnumerations import MassBalanceTypeEnum
-from DataObjects.Glacier import Glacier
+from dataflow.DataWriters.FileWriters.Database.LengthChangeWriter import CopyLengthChangeData
+from dataflow.DataWriters.DatabaseWriters.MassBalanceWriter import MassBalanceWriter
+from dataflow.DataReaders.VawFileReaders.LengthChangeReader import LengthChangeReader
+from dataflow.DataReaders.VawFileReaders.MassBalanceReader import MassBalanceReader
+from dataflow.DataReaders.DatabaseReaders.GlacierReader import GlacierReader
+from dataflow.DataObjects.Exceptions.GlacierNotFoundError import GlacierNotFoundError
+from dataflow.DataObjects.MassBalance import MassBalanceObservation
+from dataflow.DataObjects.MassBalance import MassBalanceFixDate
+from dataflow.DataObjects.Enumerations.MassBalanceEnumerations import MassBalanceTypeEnum
+from dataflow.DataObjects.Glacier import Glacier
 
 import matplotlib.pyplot as plt
 
 import configparser
 import os
 import sys
+
 
 def plotMassBalance(glacier):
     '''

--- a/dataflow/samplePlotVolumeChange.py
+++ b/dataflow/samplePlotVolumeChange.py
@@ -10,8 +10,8 @@ import configparser
 import os
 import sys
 
-from DataReaders.DatabaseReaders.GlacierReader import GlacierReader
-from DataReaders.DatabaseReaders.VolumeChangeReader import VolumeChangeReader
+from dataflow.DataReaders.DatabaseReaders.GlacierReader import GlacierReader
+from dataflow.DataReaders.DatabaseReaders.VolumeChangeReader import VolumeChangeReader
 
 def plotVolumeChange(glacier):
     '''


### PR DESCRIPTION
PyCharm comlains for me that it cannot find certain modules. To avoid this, the usual way people do it is to use absolute imports from the top level repository.

We don't run tests, so I hope I did not break anything "blindly".